### PR TITLE
Allow dump request/response body to opentracing's tags

### DIFF
--- a/jaegertracing/body_dump_response_writer.go
+++ b/jaegertracing/body_dump_response_writer.go
@@ -1,0 +1,29 @@
+package jaegertracing
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+)
+
+type bodyDumpResponseWriter struct {
+	io.Writer
+	http.ResponseWriter
+}
+
+func (w *bodyDumpResponseWriter) WriteHeader(code int) {
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *bodyDumpResponseWriter) Write(b []byte) (int, error) {
+	return w.Writer.Write(b)
+}
+
+func (w *bodyDumpResponseWriter) Flush() {
+	w.ResponseWriter.(http.Flusher).Flush()
+}
+
+func (w *bodyDumpResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.ResponseWriter.(http.Hijacker).Hijack()
+}


### PR DESCRIPTION
I added `IsBodyDump` to `TraceConfig`. If it equal `true`, tracing info will have request & response's body like this image.

![image](https://user-images.githubusercontent.com/25898298/90425385-d859ff80-e0e9-11ea-9497-ab534513b157.png)
