### PR TITLE
Use proper variadic arglist in NewPrometheus

### DIFF
--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -144,20 +144,10 @@ type PushGateway struct {
 }
 
 // NewPrometheus generates a new set of metrics with a certain subsystem name
-func NewPrometheus(subsystem string, skipper middleware.Skipper, customMetricsList ...[]*Metric) *Prometheus {
-	var metricsList []*Metric
+func NewPrometheus(subsystem string, skipper middleware.Skipper, customMetricsList ...*Metric) *Prometheus {
+	var metricsList []*Metric = append(customMetricsList, standardMetrics...)
 	if skipper == nil {
 		skipper = middleware.DefaultSkipper
-	}
-
-	if len(customMetricsList) > 1 {
-		panic("Too many args. NewPrometheus( string, <optional []*Metric> ).")
-	} else if len(customMetricsList) == 1 {
-		metricsList = customMetricsList[0]
-	}
-
-	for _, metric := range standardMetrics {
-		metricsList = append(metricsList, metric)
 	}
 
 	p := &Prometheus{


### PR DESCRIPTION
`NewPrometheus` uses `customMetricsList` as a single optional argument, panicking on multiple arguments and making function semantics less than obvious (I had to look up the code), while in fact using it as a variadic argument list which is then concatenated with a default set of metrics. This makes `NewPrometheus` a proper variadic function.

This is a breaking change, as this changes signature of `NewPrometheus`. To update existing code to the new signature, one can simply append the `...` operator to a metrics slice or just remove the slice use altogether.

Before:

```go
p := prometheus.NewPrometheus("subsystemName", nil, []*prometheus.Metric{metric1, metric2})
```

After:

```go
p := prometheus.NewPrometheus("subsystemName", nil, metric1, metric2)
p := prometheus.NewPrometheus("subsystemName", nil, []*prometheus.Metric{metric1, metric2}...)
```