### PR TITLE
casbin: add EnforceHandler to allow custom callback to handle enforcing.

### DIFF
--- a/.github/workflows/echo-contrib.yml
+++ b/.github/workflows/echo-contrib.yml
@@ -20,12 +20,15 @@ on:
       - '.github/**'
       - 'codecov.yml'
 
+env:
+  latest: '1.17'
+
 jobs:
   test:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: [1.14, 1.15, 1.16]
+        go: [1.14, 1.15, 1.16, 1.17]
     name: ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -39,17 +42,19 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: Install Dependencies
-        run: go get -u honnef.co/go/tools/cmd/staticcheck@latest
+      - name: Run static checks
+        if: matrix.go == env.latest && matrix.os == 'ubuntu-latest'
+        run: |
+          go get -u honnef.co/go/tools/cmd/staticcheck@latest
+          staticcheck -tests=false ./...
 
       - name: Run Tests
         run: |
-          staticcheck -tests=false ./...
           go test -race --coverprofile=coverage.coverprofile --covermode=atomic ./...
 
       - name: Upload coverage to Codecov
-        if: success() && matrix.go == 1.16 && matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v1
+        if: success() && matrix.go == env.latest && matrix.os == 'ubuntu-latest'
+        uses: codecov/codecov-action@v2
         with:
           token:
           fail_ci_if_error: false
@@ -58,7 +63,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go: [1.16]
+        go: [1.17]
     name: Benchmark comparison ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/echo-contrib.yml
+++ b/.github/workflows/echo-contrib.yml
@@ -20,15 +20,14 @@ on:
       - '.github/**'
       - 'codecov.yml'
 
-env:
-  latest: '1.17'
-
 jobs:
   test:
+    env:
+      latest: '1.17'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        go: [1.14, 1.15, 1.16, 1.17]
+        go: ['1.14', '1.15', '1.16', '1.17']
     name: ${{ matrix.os }} @ Go ${{ matrix.go }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -56,7 +55,6 @@ jobs:
         if: success() && matrix.go == env.latest && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v2
         with:
-          token:
           fail_ci_if_error: false
   benchmark:
     needs: test


### PR DESCRIPTION
casbin: 
* add EnforceHandler to allow custom callback to handle enforcing.
* add ErrorHandler to allow custom handling of errors

CI:
* run staticcheck only for latest Go version. Adding `honnef.co/go/tools/cmd/staticcheck` in CI flow causes dependency problems with older Go versions with we also support.

This should be enought to handle cases for: #58,  #61 and #65