### PR TITLE
fix: improve error message when _session_store is missing from context

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -36,7 +36,7 @@ var (
 func Get(name string, c echo.Context) (*sessions.Session, error) {
 	s := c.Get(key)
 	if s == nil {
-		return nil, fmt.Errorf("%q session not found", name)
+		return nil, fmt.Errorf("%q session store not found", key)
 	}
 	store := s.(sessions.Store)
 	return store.Get(c.Request(), name)

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -52,10 +52,13 @@ func TestMiddleware(t *testing.T) {
 	assert.NoError(t, h(c))
 	assert.Contains(t, rec.Header().Get(echo.HeaderSetCookie), "labstack.com")
 
-	e = echo.New()
-	req = httptest.NewRequest(echo.GET, "/", nil)
-	rec = httptest.NewRecorder()
-	c = e.NewContext(req, rec)
+}
+
+func TestGetSessionMissingStore(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(echo.GET, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
 	_, err := Get("test", c)
 
 	assert.EqualError(t, err, fmt.Sprintf("%q session store not found", key))

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -50,4 +51,12 @@ func TestMiddleware(t *testing.T) {
 	h = mw(handler)
 	assert.NoError(t, h(c))
 	assert.Contains(t, rec.Header().Get(echo.HeaderSetCookie), "labstack.com")
+
+	e = echo.New()
+	req = httptest.NewRequest(echo.GET, "/", nil)
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec)
+	_, err := Get("test", c)
+
+	assert.EqualError(t, err, fmt.Sprintf("%q session store not found", key))
 }


### PR DESCRIPTION
Hi there 👋

I was just working with session contrib and found out that the error message when getting the session from echo context does not reflect the real cause.

I've added a test and changed the error message.

Please let me know if I'm wrong or if I need to add a separate test or modify something to comply with code style! 