### PR TITLE
feat(middleware): Add geofencing middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ jaegertracing | Jaeger tracer middleware | [carlosedp](https://github.com/carlos
 prometheus | Prometheus metrics | [carlosedp](https://github.com/carlosedp)
 pprof      | pprof middlware | [arun0009](https://github.com/arun0009)
 zipkin | [Zipkin](https://github.com/openzipkin/zipkin-go) middleware | [arun0009](https://github.com/arun0009)
+geofence | Geofencing middleware backed by [circa10a/go-geofence](https://github.com/circa10a/go-geofence) | [circa10a](https://github.com/circa10a)

--- a/geofence/README.md
+++ b/geofence/README.md
@@ -1,0 +1,71 @@
+# geofence
+
+Geofencing middleware that allows you to define a physical radius for clients to access your webserver.
+
+Powered by [go-geofence](https://github.com/circa10a/go-geofence) and [freegeoip.app](https://freegeoip.app/).
+
+## Usage
+
+First, you will need a free API Token from [freegeoip.app](https://freegeoip.app/).
+
+```go
+package main
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/circa10a/go-geofence"
+	echogeofence "github.com/labstack/echo-contrib/geofence"
+	"github.com/labstack/echo/v4"
+)
+
+func main() {
+	e := echo.New()
+	e.IPExtractor = echo.ExtractIPDirect()
+	geofence, err := geofence.New(&geofence.Config{
+		// Compare incoming traffic to the current IP address running echo. This can be a set to a different IP address to geofence.
+		IPAddress: "",
+		// REQUIRED Freegeoip.app API token. Free allows 15,000 requests per hour. (caching will mitigate this)
+		Token: "<API TOKEN>",
+		// Maximum radius of the geofence in kilometers, only clients less than or equal to this distance will be allowed. (1 kilometer)
+		Radius: 1.0,
+		// Allow 192.X, 172.X, 10.X and loopback addresses
+		AllowPrivateIPAddresses: true
+		// 1 week, -1 for indefinite (until restart)
+		CacheTTL: 7 * (24 * time.Hour),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	e.GET("/", func(c echo.Context) error {
+		return c.String(http.StatusOK, "Hello, World!")
+	}, echogeofence.Middleware(geofence))
+
+	e.Start(":8080")
+}
+```
+
+## Rejecting Requests
+
+For clients not within the geofence radius, a `403 Forbidden` response will be returned like so:
+
+```json
+{
+  "message": "Forbidden"
+}
+```
+
+## Troubleshooting
+
+If you're behind a proxy, you'll want to perform the correct IP extraction method based on your setup. See the [echo docs](https://echo.labstack.com/guide/ip-address/) for more.
+
+To view the IP address being validated, use this logging config to view the remote ip:
+
+```go
+e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
+  Format: "method=${method}, uri=${uri}, status=${status}, remote_ip=${remote_ip}\n",
+}))
+```

--- a/geofence/geofence.go
+++ b/geofence/geofence.go
@@ -1,0 +1,37 @@
+package echogeofence
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// IsAddressNearChecker is an interface that guarantees the middleware is compatible with multiple libraries
+// Currently satisfied with the go-geofence library
+type IsAddressNearChecker interface {
+	IsIPAddressNear(ipAddress string) (bool, error)
+}
+
+// Middleware looks up the coordinates of a client to see if it's nearby
+func Middleware(geofence IsAddressNearChecker) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			// Get client ip
+			ipAddress := c.RealIP()
+
+			// Check if IP address is within defined radius
+			isAllowed, err := geofence.IsIPAddressNear(ipAddress)
+			if err != nil {
+				return err
+			}
+
+			// Return forbidden if not within defined radius
+			if !isAllowed {
+				return echo.NewHTTPError(http.StatusForbidden, "Forbidden")
+			}
+
+			// If close enough, allow to proceed
+			return next(c)
+		}
+	}
+}

--- a/geofence/geofence_test.go
+++ b/geofence/geofence_test.go
@@ -1,0 +1,77 @@
+package echogeofence
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/circa10a/go-geofence"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMiddleware(t *testing.T) {
+	tests := []struct {
+		geofence             *geofence.Config
+		name                 string
+		remoteAddr           string
+		expectedResponseCode int
+	}{
+		{
+			name:                 "PrivateIPSkip",
+			expectedResponseCode: 200,
+			geofence: &geofence.Config{
+				IPAddress:               "",
+				Token:                   "fake",
+				Radius:                  0,
+				AllowPrivateIPAddresses: true,
+				CacheTTL:                0,
+			},
+			remoteAddr: "192.168.1.100:80",
+		},
+		{
+			name:                 "InvalidIPFormat",
+			expectedResponseCode: 500,
+			geofence: &geofence.Config{
+				IPAddress: "",
+				Token:     "fake",
+				Radius:    0,
+				CacheTTL:  0,
+			},
+			remoteAddr: "0.0.0.0",
+		},
+		{
+			name:                 "InvalidToken",
+			expectedResponseCode: 500,
+			geofence: &geofence.Config{
+				IPAddress: "",
+				Token:     "fake",
+				Radius:    0,
+				CacheTTL:  0,
+			},
+			remoteAddr: "0.0.0.0:80",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			e := echo.New()
+
+			geofence, _ := geofence.New(test.geofence)
+
+			e.GET("/", func(c echo.Context) error {
+				return c.String(http.StatusOK, "Hello, World!")
+			}, Middleware(geofence))
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			res := httptest.NewRecorder()
+
+			if test.remoteAddr != "" {
+				req.RemoteAddr = test.remoteAddr
+			}
+
+			e.ServeHTTP(res, req)
+			assert.Equal(t, test.expectedResponseCode, res.Code)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/appleboy/gofight/v2 v2.1.2
 	github.com/casbin/casbin/v2 v2.40.6
+	github.com/circa10a/go-geofence v0.5.0
 	github.com/gorilla/context v1.1.1
 	github.com/gorilla/sessions v1.2.1
 	github.com/labstack/echo/v4 v4.6.1
@@ -18,17 +19,20 @@ require (
 )
 
 require (
+	github.com/EpicStep/go-simple-geo/v2 v2.0.1 // indirect
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2 // indirect
 	github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-resty/resty/v2 v2.7.0 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/gorilla/securecookie v1.1.1 // indirect
 	github.com/mattn/go-colorable v0.1.11 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
@@ -38,8 +42,8 @@ require (
 	github.com/valyala/fasttemplate v1.2.1 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	golang.org/x/crypto v0.0.0-20210920023735-84f357641f63 // indirect
-	golang.org/x/net v0.0.0-20210917221730-978cfadd31cf // indirect
-	golang.org/x/sys v0.0.0-20211103235746-7861aae1554b // indirect
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
+	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324 // indirect
 	google.golang.org/grpc v1.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/EpicStep/go-simple-geo/v2 v2.0.1 h1:+suZRwgZVZCuH8NXNE/D+7EH0iY90dqx2eA3faQ2v7c=
+github.com/EpicStep/go-simple-geo/v2 v2.0.1/go.mod h1:ELLmk0tgdNH4BLiL+jrSg+X6nz3aMgZrTRnHPWsaXvQ=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob0t8PQPMybUNFM=
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible h1:1G1pk05UrOh0NlF1oeaaix1x8XzrfjIDK47TY0Zehcw=
@@ -60,6 +62,8 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/circa10a/go-geofence v0.5.0 h1:pmxfcW9yihTQ09SYVefB6kehW0WGvshoO3xEMwk9vgs=
+github.com/circa10a/go-geofence v0.5.0/go.mod h1:mxd1yyPw/Dr/dfn7OA8OR6hdUW9UusX4OgmpwbyNweA=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -93,6 +97,8 @@ github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vb
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-resty/resty/v2 v2.7.0 h1:me+K9p3uhSmXtrBZ4k9jcEAfJmuC8IivWHwaLZwPrFY=
+github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSMVIq3w7q0I=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -168,6 +174,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/jarcoal/httpmock v1.0.8 h1:8kI16SoO6LQKgPE7PvQuV+YuD/inwHd7fOOe2zMbo4k=
+github.com/jarcoal/httpmock v1.0.8/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jcmturner/aescts/v2 v2.0.0/go.mod h1:AiaICIRyfYg35RUkr8yESTqvSy7csK90qZ5xfvvsoNs=
 github.com/jcmturner/dnsutils/v2 v2.0.0/go.mod h1:b0TnjGOvI/n42bZa+hmXL+kFJZsFT7G4t3HTlQ184QM=
 github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
@@ -231,6 +239,8 @@ github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/openzipkin/zipkin-go v0.3.0 h1:XtuXmOLIXLjiU2XduuWREDT0LOKtSgos/g7i7RYyoZQ=
 github.com/openzipkin/zipkin-go v0.3.0/go.mod h1:4c3sLeE8xjNqehmF5RpAFLPLJxXscc0R4l6Zg0P1tTQ=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -382,8 +392,11 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210913180222-943fd674d43e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20210917221730-978cfadd31cf h1:R150MpwJIv1MpS0N/pc+NhTM8ajzvlmxlY5OYsrevXQ=
 golang.org/x/net v0.0.0-20210917221730-978cfadd31cf/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211029224645-99673261e6eb/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=
+golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -449,9 +462,11 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211103235746-7861aae1554b h1:1VkfZQv42XQlA/jchYumAnv1UPo6RgF9rJFkTgZIxO4=
 golang.org/x/sys v0.0.0-20211103235746-7861aae1554b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
This PR adds middleware that allows consumers to configure a geofence that rejects requests based on relative IP address location details.

A user can define a physical radius such as 1 kilometer, then by using [go-geofence](https://github.com/circa10a/go-geofence), the location distance is determined and will either reject the request or call `next()`.