### PR TITLE
Swap the position of the argument, update test

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -33,7 +33,7 @@ var (
 )
 
 // Get returns a named session.
-func Get(name string, c echo.Context) (*sessions.Session, error) {
+func Get(c echo.Context, name string) (*sessions.Session, error) {
 	s := c.Get(key)
 	if s == nil {
 		return nil, fmt.Errorf("%q session store not found", key)

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -17,7 +17,7 @@ func TestMiddleware(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 	handler := func(c echo.Context) error {
-		sess, _ := Get("test", c)
+		sess, _ := Get(c, "test")
 		sess.Options.Domain = "labstack.com"
 		sess.Values["foo"] = "bar"
 		if err := sess.Save(c.Request(), c.Response()); err != nil {
@@ -59,7 +59,7 @@ func TestGetSessionMissingStore(t *testing.T) {
 	req := httptest.NewRequest(echo.GET, "/", nil)
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
-	_, err := Get("test", c)
+	_, err := Get(c, "test")
 
 	assert.EqualError(t, err, fmt.Sprintf("%q session store not found", key))
 }


### PR DESCRIPTION
Match the order of `store.Get()` arguments in `gorilla/sessions`.

https://github.com/gorilla/sessions/blob/a6a8e49c83a2dba9cf7f486feb2662d6439851f2/store.go#L23

It is unlikely to affect the operation, but I felt uncomfortable when reading the code that the order of arguments was reversed, so I will submit a pull request. This is a minor fix, but please consider it.