### PR TITLE
Issue #88 Adding Host Label to all metrics

### DIFF
--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -76,7 +76,7 @@ var reqDur = &Metric{
 	ID:          "reqDur",
 	Name:        "request_duration_seconds",
 	Description: "The HTTP request latencies in seconds.",
-	Args:        []string{"code", "method", "url"},
+	Args:        []string{"code", "method", "host", "url"},
 	Type:        "histogram_vec",
 	Buckets:     reqDurBuckets}
 
@@ -84,7 +84,7 @@ var resSz = &Metric{
 	ID:          "resSz",
 	Name:        "response_size_bytes",
 	Description: "The HTTP response sizes in bytes.",
-	Args:        []string{"code", "method", "url"},
+	Args:        []string{"code", "method", "host", "url"},
 	Type:        "histogram_vec",
 	Buckets:     resSzBuckets}
 
@@ -92,7 +92,7 @@ var reqSz = &Metric{
 	ID:          "reqSz",
 	Name:        "request_size_bytes",
 	Description: "The HTTP request sizes in bytes.",
-	Args:        []string{"code", "method", "url"},
+	Args:        []string{"code", "method", "host", "url"},
 	Type:        "histogram_vec",
 	Buckets:     reqSzBuckets}
 
@@ -439,12 +439,12 @@ func (p *Prometheus) HandlerFunc(next echo.HandlerFunc) echo.HandlerFunc {
 		}
 
 		statusStr := strconv.Itoa(status)
-		p.reqDur.WithLabelValues(statusStr, c.Request().Method, url).Observe(elapsed)
+		p.reqDur.WithLabelValues(statusStr, c.Request().Method, p.RequestCounterHostLabelMappingFunc(c), url).Observe(elapsed)
 		p.reqCnt.WithLabelValues(statusStr, c.Request().Method, p.RequestCounterHostLabelMappingFunc(c), url).Inc()
-		p.reqSz.WithLabelValues(statusStr, c.Request().Method, url).Observe(float64(reqSz))
+		p.reqSz.WithLabelValues(statusStr, c.Request().Method, p.RequestCounterHostLabelMappingFunc(c), url).Observe(float64(reqSz))
 
 		resSz := float64(c.Response().Size)
-		p.resSz.WithLabelValues(statusStr, c.Request().Method, url).Observe(resSz)
+		p.resSz.WithLabelValues(statusStr, c.Request().Method, p.RequestCounterHostLabelMappingFunc(c), url).Observe(resSz)
 
 		return err
 	}

--- a/prometheus/prometheus_test.go
+++ b/prometheus/prometheus_test.go
@@ -48,13 +48,14 @@ func TestPrometheus_Buckets(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), fmt.Sprintf("%s_request_duration_seconds", p.Subsystem))
-	assert.Contains(t, rec.Body.String(), `host="example.com"`, "host must be present")
-	assert.Regexp(t, "request_duration_seconds.*le=\"0.005\"", rec.Body.String(), "duration should have time bucket (like, 0.005s)")
-	assert.NotRegexp(t, "request_duration_seconds.*le=\"512000\"", rec.Body.String(), "duration should NOT have a size bucket (like, 512K)")
-	assert.Regexp(t, "response_size_bytes.*le=\"512000\"", rec.Body.String(), "response size should have a 512K (size) bucket")
-	assert.NotRegexp(t, "response_size_bytes.*le=\"0.005\"", rec.Body.String(), "response size should NOT have time bucket (like, 0.005s)")
-	assert.Regexp(t, "request_size_bytes.*le=\"512000\"", rec.Body.String(), "request size should have a 512K (size) bucket")
-	assert.NotRegexp(t, "request_size_bytes.*le=\"0.005\"", rec.Body.String(), "request should NOT have time bucket (like, 0.005s)")
+
+	body := rec.Body.String()
+	assert.Contains(t, body, `echo_request_duration_seconds_bucket{code="404",host="example.com",method="GET",url="/ping",le="0.005"}`, "duration should have time bucket (like, 0.005s)")
+	assert.NotContains(t, body, `echo_request_duration_seconds_bucket{code="404",host="example.com",method="GET",url="/ping",le="512000"}`, "duration should NOT have a size bucket (like, 512K)")
+	assert.Contains(t, body, `echo_request_size_bytes_bucket{code="404",host="example.com",method="GET",url="/ping",le="1024"}`, "request size should have a 1024k (size) bucket")
+	assert.NotContains(t, body, `echo_request_size_bytes_bucket{code="404",host="example.com",method="GET",url="/ping",le="0.005"}`, "request size should NOT have time bucket (like, 0.005s)")
+	assert.Contains(t, body, `echo_response_size_bytes_bucket{code="404",host="example.com",method="GET",url="/ping",le="1024"}`, "response size should have a 1024k (size) bucket")
+	assert.NotContains(t, body, `echo_response_size_bytes_bucket{code="404",host="example.com",method="GET",url="/ping",le="0.005"}`, "response size should NOT have time bucket (like, 0.005s)")
 
 	unregister(p)
 }

--- a/prometheus/prometheus_test.go
+++ b/prometheus/prometheus_test.go
@@ -48,6 +48,7 @@ func TestPrometheus_Buckets(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), fmt.Sprintf("%s_request_duration_seconds", p.Subsystem))
+	assert.Contains(t, rec.Body.String(), `host="example.com"`, "host must be present")
 	assert.Regexp(t, "request_duration_seconds.*le=\"0.005\"", rec.Body.String(), "duration should have time bucket (like, 0.005s)")
 	assert.NotRegexp(t, "request_duration_seconds.*le=\"512000\"", rec.Body.String(), "duration should NOT have a size bucket (like, 512K)")
 	assert.Regexp(t, "response_size_bytes.*le=\"512000\"", rec.Body.String(), "response size should have a 512K (size) bucket")
@@ -141,6 +142,7 @@ func TestMetricsGenerated(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rec.Code)
 	s := rec.Body.String()
 	assert.Contains(t, s, `url="/ping"`, "path must be present")
+	assert.Contains(t, s, `host="example.com"`, "host must be present")
 
 	unregister(p)
 }


### PR DESCRIPTION
Added Changes for https://github.com/labstack/echo-contrib/issues/88. 

This change makes sense as the Host Label is crucial to identify similar metrics across multiple services with same running endpoints
