### PR TITLE
Add SDPX licence identifier to source files

### DIFF
--- a/casbin/casbin.go
+++ b/casbin/casbin.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2017 LabStack and Echo contributors
+
 /* Package casbin provides middleware to enable ACL, RBAC, ABAC authorization support.
 
 Simple example:

--- a/casbin/casbin_test.go
+++ b/casbin/casbin_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2017 LabStack and Echo contributors
+
 package casbin
 
 import (

--- a/echo.go
+++ b/echo.go
@@ -1,1 +1,4 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2017 LabStack and Echo contributors
+
 package echo

--- a/echoprometheus/README.md
+++ b/echoprometheus/README.md
@@ -5,7 +5,7 @@ package main
 
 import (
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo-contrib/prometheus/echoprometheus"
+	"github.com/labstack/echo-contrib/echoprometheus"
 )
 
 func main() {

--- a/echoprometheus/prometheus.go
+++ b/echoprometheus/prometheus.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2017 LabStack and Echo contributors
+
 /*
 Package echoprometheus provides middleware to add Prometheus metrics.
 */

--- a/echoprometheus/prometheus_test.go
+++ b/echoprometheus/prometheus_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2017 LabStack and Echo contributors
+
 package echoprometheus
 
 import (

--- a/jaegertracing/jaegertracing.go
+++ b/jaegertracing/jaegertracing.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2017 LabStack and Echo contributors
+
 /*
 Package jaegertracing provides middleware to Opentracing using Jaeger.
 

--- a/jaegertracing/jaegertracing_test.go
+++ b/jaegertracing/jaegertracing_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2017 LabStack and Echo contributors
+
 package jaegertracing
 
 import (

--- a/jaegertracing/response_dumper.go
+++ b/jaegertracing/response_dumper.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2017 LabStack and Echo contributors
+
 package jaegertracing
 
 import (

--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2017 LabStack and Echo contributors
+
 package pprof
 
 import (

--- a/pprof/pprof_test.go
+++ b/pprof/pprof_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2017 LabStack and Echo contributors
+
 package pprof
 
 import (

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2017 LabStack and Echo contributors
+
 /*
 Package prometheus provides middleware to add Prometheus metrics.
 

--- a/prometheus/prometheus_test.go
+++ b/prometheus/prometheus_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2017 LabStack and Echo contributors
+
 package prometheus
 
 import (

--- a/session/session.go
+++ b/session/session.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2017 LabStack and Echo contributors
+
 package session
 
 import (

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2017 LabStack and Echo contributors
+
 package session
 
 import (

--- a/zipkintracing/response_writer.go
+++ b/zipkintracing/response_writer.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2017 LabStack and Echo contributors
+
 package zipkintracing
 
 import (

--- a/zipkintracing/tracing.go
+++ b/zipkintracing/tracing.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2017 LabStack and Echo contributors
+
 package zipkintracing
 
 import (
@@ -66,7 +69,7 @@ func TraceFunc(c echo.Context, spanName string, spanTags Tags, tracer *zipkin.Tr
 	return finishSpan
 }
 
-//TraceProxy middleware that traces reverse proxy
+// TraceProxy middleware that traces reverse proxy
 func TraceProxy(tracer *zipkin.Tracer) echo.MiddlewareFunc {
 	config := DefaultTraceProxyConfig
 	config.Tracer = tracer
@@ -111,7 +114,7 @@ func TraceProxyWithConfig(config TraceProxyConfig) echo.MiddlewareFunc {
 	}
 }
 
-//TraceServer middleware that traces server calls
+// TraceServer middleware that traces server calls
 func TraceServer(tracer *zipkin.Tracer) echo.MiddlewareFunc {
 	config := DefaultTraceServerConfig
 	config.Tracer = tracer

--- a/zipkintracing/tracing_test.go
+++ b/zipkintracing/tracing_test.go
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: © 2017 LabStack and Echo contributors
+
 package zipkintracing
 
 import (


### PR DESCRIPTION
Add SDPX licence identifier to source files. https://spdx.org/licenses/ 

There are cases when Echo code has been copied to other projects and due to the fact that we do not have licence at the start of file with copyright line and even with full MIT message at the beginning of the file  without copyright statement the information is last that Echo was the original source.   Yes, MIT allows copying but licence must be preserved.   [SPDX](https://spdx.org/licenses/) tags are shorter way to achieve what I am trying to do here -  when code is copied it is easy to understand that Echo was the source (removing licence notes would be against the licences to my understanding). 

so every go file gets
```
// SPDX-License-Identifier: MIT
// SPDX-FileCopyrightText: © 2017 LabStack and Echo contributors
```

Note: copyright line number is " year of publication " and does not need to be updated