### PR TITLE
Fix docs: Set correct go import path for `echoprometheus` package

### DIFF
--- a/echoprometheus/README.md
+++ b/echoprometheus/README.md
@@ -5,7 +5,7 @@ package main
 
 import (
 	"github.com/labstack/echo/v4"
-	"github.com/labstack/echo-contrib/prometheus/echoprometheus"
+	"github.com/labstack/echo-contrib/echoprometheus"
 )
 
 func main() {


### PR DESCRIPTION
The README of the new prometheus middleware states the wrong import path.