### PR TITLE
Jaeger Middleware: Missing Span Context in Proxied Request Header

### DIFF
--- a/jaegertracing/jaegertracing.go
+++ b/jaegertracing/jaegertracing.go
@@ -213,6 +213,9 @@ func TraceWithConfig(config TraceConfig) echo.MiddlewareFunc {
 				}
 			}()
 
+			// inject Jaeger context into request header
+			config.Tracer.Inject(sp.Context(), opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(c.Request().Header))
+
 			// call next middleware / controller
 			err = next(c)
 			if err != nil {


### PR DESCRIPTION
# Description
I tried to create a simple Echo reverse proxy (echo/v4/middleware) which connects to 2 simple Echo services (Hello World), both with the Jaeger middleware connecting to the jaeger/all-in-one docker image. I noticed that each of the services was creating their own trace in Jaeger rather than the proxy propagating through to the hello world instance. The correct headers were not being set for the context to be propagated.

Before:
```
james@james-desktop:~$ docker logs jaeger-server1 --follow

   ____    __
  / __/___/ /  ___
 / _// __/ _ \/ _ \
/___/\__/_//_/\___/ v4.11.4
High performance, minimalist Go web framework
https://echo.labstack.com
____________________________________O/_______
                                    O\
⇨ http server started on [::]:8080
Context: <nil>
Error: opentracing: SpanContext not found in Extract carrier
Creating New Span Context
Request Header: map[Accept:[*/*] Accept-Encoding:[gzip] User-Agent:[curl/7.81.0] X-Forwarded-For:[192.168.96.1] X-Forwarded-Proto:[http] X-Real-Ip:[192.168.96.1]]
{"time":"2024-02-17T19:34:10.364168015Z","id":"","remote_ip":"192.168.96.1","host":"localhost:8080","method":"GET","uri":"/","user_agent":"curl/7.81.0","status":200,"error":"","latency":87721,"latency_human":"87.721µs","bytes_in":0,"bytes_out":13}

```

With the default settings, the ```config.Tracer.Extract``` function at the start of the Jaeger middleware is looking for the trace context in the header value "uber-trace-id" (```jaeger.TraceContextHeaderName```). This fix adds the context value in the header by using the ```config.Tracer.Inject``` function.

After:
```
james@james-desktop:~$ docker logs jaeger-server1 --follow

   ____    __
  / __/___/ /  ___
 / _// __/ _ \/ _ \
/___/\__/_//_/\___/ v4.11.4
High performance, minimalist Go web framework
https://echo.labstack.com
____________________________________O/_______
                                    O\
⇨ http server started on [::]:8080
Context: 08a020d7daedd7d2:08a020d7daedd7d2:0000000000000000:1
Error: <nil>
Use Existing Span Context
Request Header: map[Accept:[*/*] Accept-Encoding:[gzip] Uber-Trace-Id:[08a020d7daedd7d2:129bd5d44715283c:08a020d7daedd7d2:1] User-Agent:[curl/7.81.0] X-Forwarded-For:[192.168.96.1] X-Forwarded-Proto:[http] X-Real-Ip:[192.168.96.1]]
{"time":"2024-02-17T19:34:43.39425835Z","id":"","remote_ip":"192.168.96.1","host":"localhost:8080","method":"GET","uri":"/","user_agent":"curl/7.81.0","status":200,"error":"","latency":114142,"latency_human":"114.142µs","bytes_in":0,"bytes_out":13}

```

See also: [serializing-to-the-wire](https://github.com/opentracing/opentracing-go?tab=readme-ov-file#serializing-to-the-wire)

## TLDR
Fix Jaeger middleware when used with a proxy by adding the trace context to the request header.
