### PR TITLE
Conditionally set url label for 404 responses

### DIFF
--- a/echoprometheus/prometheus.go
+++ b/echoprometheus/prometheus.go
@@ -137,11 +137,6 @@ func NewMiddleware(subsystem string) echo.MiddlewareFunc {
 
 // NewMiddlewareWithConfig creates new instance of middleware using given configuration.
 func NewMiddlewareWithConfig(config MiddlewareConfig) echo.MiddlewareFunc {
-	// for backwared compatiblity
-	if config.SetPathFor404 == nil {
-		setPathFor404 := true
-		config.SetPathFor404 = &setPathFor404
-	}
 	mw, err := config.ToMiddleware()
 	if err != nil {
 		panic(err)
@@ -151,6 +146,12 @@ func NewMiddlewareWithConfig(config MiddlewareConfig) echo.MiddlewareFunc {
 
 // ToMiddleware converts configuration to middleware or returns an error.
 func (conf MiddlewareConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
+	// for backwared compatiblity
+	if conf.SetPathFor404 == nil {
+		setPathFor404 := true
+		conf.SetPathFor404 = &setPathFor404
+	}
+
 	if conf.timeNow == nil {
 		conf.timeNow = time.Now
 	}

--- a/echoprometheus/prometheus.go
+++ b/echoprometheus/prometheus.go
@@ -74,7 +74,8 @@ type MiddlewareConfig struct {
 
 	timeNow func() time.Time
 
-	// If SetPathFor404 is false, all 404 responses will have the same `url` label and thus won't generate new metrics
+	// If SetPathFor404 is false, all 404 responses (due to non-matching route) will have the same `url` label and
+	// thus won't generate new metrics.
 	SetPathFor404 *bool
 }
 
@@ -276,7 +277,7 @@ func (conf MiddlewareConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 			values[0] = strconv.Itoa(status)
 			values[1] = c.Request().Method
 			values[2] = c.Request().Host
-			// as of Echo v4.10.1 path is empty for 404 cases (when router did not find any matching routes)
+			// as of Echo v4.10.1 an empty c.Path() means the router did not find any matching routes (404)
 			if c.Path() != "" || (conf.SetPathFor404 != nil && *conf.SetPathFor404) {
 				values[3] = url
 			}

--- a/echoprometheus/prometheus.go
+++ b/echoprometheus/prometheus.go
@@ -270,7 +270,7 @@ func (conf MiddlewareConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 			values[0] = strconv.Itoa(status)
 			values[1] = c.Request().Method
 			values[2] = c.Request().Host
-			if !(status == http.StatusNotFound && conf.SetPathFor404) {
+			if status != http.StatusNotFound || conf.SetPathFor404 {
 				values[3] = url
 			}
 			values[3] = url

--- a/echoprometheus/prometheus.go
+++ b/echoprometheus/prometheus.go
@@ -74,9 +74,9 @@ type MiddlewareConfig struct {
 
 	timeNow func() time.Time
 
-	// If SetPathFor404 is false, all 404 responses (due to non-matching route) will have the same `url` label and
+	// If DoNotUseURLFor404 is true, all 404 responses (due to non-matching route) will have the same `url` label and
 	// thus won't generate new metrics.
-	SetPathFor404 *bool
+	DoNotUseURLFor404 bool
 }
 
 type LabelValueFunc func(c echo.Context, err error) string
@@ -147,12 +147,6 @@ func NewMiddlewareWithConfig(config MiddlewareConfig) echo.MiddlewareFunc {
 
 // ToMiddleware converts configuration to middleware or returns an error.
 func (conf MiddlewareConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
-	// for backwared compatiblity
-	if conf.SetPathFor404 == nil {
-		setPathFor404 := true
-		conf.SetPathFor404 = &setPathFor404
-	}
-
 	if conf.timeNow == nil {
 		conf.timeNow = time.Now
 	}
@@ -278,7 +272,7 @@ func (conf MiddlewareConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 			values[1] = c.Request().Method
 			values[2] = c.Request().Host
 			// as of Echo v4.10.1 an empty c.Path() means the router did not find any matching routes (404)
-			if c.Path() != "" || (conf.SetPathFor404 != nil && *conf.SetPathFor404) {
+			if c.Path() != "" || !conf.DoNotUseURLFor404 {
 				values[3] = url
 			}
 			for _, cv := range customValuers {

--- a/echoprometheus/prometheus.go
+++ b/echoprometheus/prometheus.go
@@ -132,7 +132,7 @@ func NewHandlerWithConfig(config HandlerConfig) echo.HandlerFunc {
 
 // NewMiddleware creates new instance of middleware using Prometheus default registry.
 func NewMiddleware(subsystem string) echo.MiddlewareFunc {
-	return NewMiddlewareWithConfig(MiddlewareConfig{Subsystem: subsystem})
+	return NewMiddlewareWithConfig(MiddlewareConfig{Subsystem: subsystem, SetPathFor404: true})
 }
 
 // NewMiddlewareWithConfig creates new instance of middleware using given configuration.

--- a/echoprometheus/prometheus.go
+++ b/echoprometheus/prometheus.go
@@ -275,7 +275,8 @@ func (conf MiddlewareConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 			values[0] = strconv.Itoa(status)
 			values[1] = c.Request().Method
 			values[2] = c.Request().Host
-			if status != http.StatusNotFound || (conf.SetPathFor404 != nil && *conf.SetPathFor404) {
+			// as of Echo v4.10.1 path is empty for 404 cases (when router did not find any matching routes)
+			if c.Path() != "" || (conf.SetPathFor404 != nil && *conf.SetPathFor404) {
 				values[3] = url
 			}
 			for _, cv := range customValuers {

--- a/echoprometheus/prometheus.go
+++ b/echoprometheus/prometheus.go
@@ -73,6 +73,9 @@ type MiddlewareConfig struct {
 	AfterNext func(c echo.Context, err error)
 
 	timeNow func() time.Time
+
+	// If SetPathFor404 is false, all 404 responses will have the same `url` label and thus won't generate new metrics
+	SetPathFor404 bool
 }
 
 type LabelValueFunc func(c echo.Context, err error) string
@@ -267,6 +270,9 @@ func (conf MiddlewareConfig) ToMiddleware() (echo.MiddlewareFunc, error) {
 			values[0] = strconv.Itoa(status)
 			values[1] = c.Request().Method
 			values[2] = c.Request().Host
+			if !(status == http.StatusNotFound && conf.SetPathFor404) {
+				values[3] = url
+			}
 			values[3] = url
 			for _, cv := range customValuers {
 				values[cv.index] = cv.valueFunc(c, err)

--- a/echoprometheus/prometheus_test.go
+++ b/echoprometheus/prometheus_test.go
@@ -283,7 +283,7 @@ func TestRunPushGatewayGatherer(t *testing.T) {
 func TestSetPathFor404NoMatchingRoute(t *testing.T) {
 	e := echo.New()
 
-	e.Use(NewMiddlewareWithConfig(MiddlewareConfig{DoNotUseURLFor404: true, Subsystem: defaultSubsystem}))
+	e.Use(NewMiddlewareWithConfig(MiddlewareConfig{DoNotUseRequestPathFor404: true, Subsystem: defaultSubsystem}))
 	e.GET("/metrics", NewHandler())
 
 	assert.Equal(t, http.StatusNotFound, request(e, "/nonExistentPath"))
@@ -301,7 +301,7 @@ func TestSetPathFor404Logic(t *testing.T) {
 	unregisterDefaults("myapp")
 	e := echo.New()
 
-	e.Use(NewMiddlewareWithConfig(MiddlewareConfig{DoNotUseURLFor404: true, Subsystem: defaultSubsystem}))
+	e.Use(NewMiddlewareWithConfig(MiddlewareConfig{DoNotUseRequestPathFor404: true, Subsystem: defaultSubsystem}))
 	e.GET("/metrics", NewHandler())
 
 	e.GET("/sample", echo.NotFoundHandler)

--- a/echoprometheus/prometheus_test.go
+++ b/echoprometheus/prometheus_test.go
@@ -275,21 +275,46 @@ func TestRunPushGatewayGatherer(t *testing.T) {
 
 	assert.EqualError(t, err, "code=400, message=post metrics request did not succeed")
 	assert.True(t, receivedMetrics)
+	unregisterDefaults("myapp")
 }
 
-func TestSetPathFor404(t *testing.T) {
+// TestSetPathFor404Logic tests when the 404 response is due to no matching route, the url is not included in the metric
+func TestSetPathFor404NoMatchingRoute(t *testing.T) {
 	e := echo.New()
 
 	setPathFor404 := false
-	e.Use(NewMiddlewareWithConfig(MiddlewareConfig{SetPathFor404: &setPathFor404}))
+	e.Use(NewMiddlewareWithConfig(MiddlewareConfig{SetPathFor404: &setPathFor404, Subsystem: defaultSubsystem}))
 	e.GET("/metrics", NewHandler())
 
 	assert.Equal(t, http.StatusNotFound, request(e, "/nonExistentPath"))
 
 	s, code := requestBody(e, "/metrics")
 	assert.Equal(t, http.StatusOK, code)
-	assert.Contains(t, s, `echo_request_duration_seconds_count{code="404",host="example.com",method="GET",url=""} 1`)
-	assert.NotContains(t, s, `echo_request_duration_seconds_count{code="404",host="example.com",method="GET",url="/nonExistentPath"} 1`)
+	assert.Contains(t, s, fmt.Sprintf(`%s_request_duration_seconds_count{code="404",host="example.com",method="GET",url=""} 1`, defaultSubsystem))
+	assert.NotContains(t, s, fmt.Sprintf(`%s_request_duration_seconds_count{code="404",host="example.com",method="GET",url="/nonExistentPath"} 1`, defaultSubsystem))
+
+	unregisterDefaults(defaultSubsystem)
+}
+
+// TestSetPathFor404Logic tests when the 404 response is due to logic, the url is included in the metric
+func TestSetPathFor404Logic(t *testing.T) {
+	unregisterDefaults("myapp")
+	e := echo.New()
+
+	setPathFor404 := false
+	e.Use(NewMiddlewareWithConfig(MiddlewareConfig{SetPathFor404: &setPathFor404, Subsystem: defaultSubsystem}))
+	e.GET("/metrics", NewHandler())
+
+	e.GET("/sample", echo.NotFoundHandler)
+
+	assert.Equal(t, http.StatusNotFound, request(e, "/sample"))
+
+	s, code := requestBody(e, "/metrics")
+	assert.Equal(t, http.StatusOK, code)
+	assert.NotContains(t, s, fmt.Sprintf(`%s_request_duration_seconds_count{code="404",host="example.com",method="GET",url=""} 1`, defaultSubsystem))
+	assert.Contains(t, s, fmt.Sprintf(`%s_request_duration_seconds_count{code="404",host="example.com",method="GET",url="/sample"} 1`, defaultSubsystem))
+
+	unregisterDefaults(defaultSubsystem)
 }
 
 func requestBody(e *echo.Echo, path string) (string, int) {

--- a/echoprometheus/prometheus_test.go
+++ b/echoprometheus/prometheus_test.go
@@ -278,12 +278,12 @@ func TestRunPushGatewayGatherer(t *testing.T) {
 	unregisterDefaults("myapp")
 }
 
-// TestSetPathFor404Logic tests when the 404 response is due to no matching route, the url is not included in the metric
+// TestSetPathFor404NoMatchingRoute tests that the url is not included in the metric when
+// the 404 response is due to no matching route
 func TestSetPathFor404NoMatchingRoute(t *testing.T) {
 	e := echo.New()
 
-	setPathFor404 := false
-	e.Use(NewMiddlewareWithConfig(MiddlewareConfig{SetPathFor404: &setPathFor404, Subsystem: defaultSubsystem}))
+	e.Use(NewMiddlewareWithConfig(MiddlewareConfig{DoNotUseURLFor404: true, Subsystem: defaultSubsystem}))
 	e.GET("/metrics", NewHandler())
 
 	assert.Equal(t, http.StatusNotFound, request(e, "/nonExistentPath"))
@@ -296,13 +296,12 @@ func TestSetPathFor404NoMatchingRoute(t *testing.T) {
 	unregisterDefaults(defaultSubsystem)
 }
 
-// TestSetPathFor404Logic tests when the 404 response is due to logic, the url is included in the metric
+// TestSetPathFor404Logic tests that the url is included in the metric when the 404 response is due to logic
 func TestSetPathFor404Logic(t *testing.T) {
 	unregisterDefaults("myapp")
 	e := echo.New()
 
-	setPathFor404 := false
-	e.Use(NewMiddlewareWithConfig(MiddlewareConfig{SetPathFor404: &setPathFor404, Subsystem: defaultSubsystem}))
+	e.Use(NewMiddlewareWithConfig(MiddlewareConfig{DoNotUseURLFor404: true, Subsystem: defaultSubsystem}))
 	e.GET("/metrics", NewHandler())
 
 	e.GET("/sample", echo.NotFoundHandler)


### PR DESCRIPTION
The MR addresses #86. I've explained about it in the original issue. TLDR; It adds a new field to the `MiddlewareConfig` to control the URL label when the response status code is 404.