### PR TITLE
Fix the deprecation comment format

### DIFF
--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -140,7 +140,8 @@ type Metric struct {
 	Buckets         []float64
 }
 
-// Prometheus contains the metrics gathered by the instance and its path
+// Prometheus contains the metrics gathered by the instance and its path.
+//
 // Deprecated: use echoprometheus package instead
 type Prometheus struct {
 	reqCnt               *prometheus.CounterVec
@@ -175,7 +176,8 @@ type PushGateway struct {
 	Job string
 }
 
-// NewPrometheus generates a new set of metrics with a certain subsystem name
+// NewPrometheus generates a new set of metrics with a certain subsystem name.
+//
 // Deprecated: use echoprometheus package instead
 func NewPrometheus(subsystem string, skipper middleware.Skipper, customMetricsList ...[]*Metric) *Prometheus {
 	var metricsList []*Metric
@@ -301,7 +303,8 @@ func (p *Prometheus) startPushTicker() {
 	}()
 }
 
-// NewMetric associates prometheus.Collector based on Metric.Type
+// NewMetric associates prometheus.Collector based on Metric.Type.
+//
 // Deprecated: use echoprometheus package instead
 func NewMetric(m *Metric, subsystem string) prometheus.Collector {
 	var metric prometheus.Collector


### PR DESCRIPTION
According to the [Go WIKI](https://go.dev/wiki/Deprecated)
> To signal that an identifier should not be used, add a **paragraph** to its doc comment that begins with Deprecated: followed by some information about the deprecation, and a recommendation on what to use instead, if applicable.

Emphasis is mine. Without putting the "Deprecated:" part to its own paragraph, automated tools and IDEs (e.g. vscode) doesn't recognize the deprecation warning.